### PR TITLE
Closes Issue#16 - published as npm packages and added readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+## Easymailing
+easymailing is a middleware for express to receive a post request from the front-end and sends out an e-mail using user configured email account.
+
+### Getting Started
+
+`npm i easymailing`
+
+#### require the npm package:
+```javascript
+const make_send_email = require("easymailing")
+```
+#### configuration:
+```javascript
+const config = {
+  user: process.env.user,
+  password: process.env.password,
+  to: 'sales@mycompany.com',
+  path: '/mail',
+}
+const send_email = make_send_email(config)
+app.use(send_email);
+```
+
+`config.user` and `config.password` is your gmail account/password used to send out the emails
+`config.to` is the email account(s) that should receive the emails. For multiple email accounts, you can replace the string with array of strings, e.g. ['sales@mycompany.com','services@mycompany.com']
+`config.path` is the path you expect to receive the email request from the front-end
+
+### Connecting with front-end 
+easymailing expects a front-end POST request to the path specified in the config. You can either build your own front-end form that sends a POST request with email, subject message in the body, or use the companion npm package easymailing-client `npm i easymailing-client`

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -1,68 +1,16 @@
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
+## Easymailing-client
+easymailing-client is a react component that provides an email form that's built to send a post request to a server.
+### Getting Started
+Install
+`npm i easymailing-client`
+Require the package
+```javascript
+import EasyMailing from 'easymailing-client';
+```
+You can use the component as:
+```javascript
+<EasyMailing baseUrl='http://localhost:3333' path='mail'>
+```
+where baseUrl is the location of your server and path is the path you would like to receive the post request.
 
-## Available Scripts
 
-In the project directory, you can run:
-
-### `yarn start`
-
-Runs the app in the development mode.<br />
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
-
-The page will reload if you make edits.<br />
-You will also see any lint errors in the console.
-
-### `yarn test`
-
-Launches the test runner in the interactive watch mode.<br />
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `yarn build`
-
-Builds the app for production to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.<br />
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `yarn eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can’t go back!**
-
-If you aren’t satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (Webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you’re on your own.
-
-You don’t have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn’t feel obligated to use this feature. However we understand that this tool wouldn’t be useful if you couldn’t customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/code-splitting
-
-### Analyzing the Bundle Size
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size
-
-### Making a Progressive Web App
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app
-
-### Advanced Configuration
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/advanced-configuration
-
-### Deployment
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/deployment
-
-### `yarn build` fails to minify
-
-This section has moved here: https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -1,23 +1,22 @@
 {
-  "name": "easymailing-front-end",
-  "version": "0.1.1",
+  "name": "easymailing-client",
+  "version": "0.1.8",
+  "main": "dist/index.js",
   "private": false,
-  "dependencies": {
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "react-scripts": "3.3.0"
-  },
   "babel": {
     "presets": [
       "@babel/preset-react"
     ]
+  },
+  "dependencies": {
+    "axios": "^0.19.2"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "publish:npm": "rm -rf dist && mkdir dist &&  babel src/components/EasyMailing/index.js -d dist --copy-files"
+    "publish:npm": "rm -rf dist && mkdir dist &&  babel src/components/EasyMailing -d dist --copy-files"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -34,13 +33,18 @@
       "last 1 safari version"
     ]
   },
+  "peerDependencies": {  
+    "axios": "^0.19.2",    
+    "react": ">=15.0.1",
+    "react-dom": ">=15.0.1"
+},
   "devDependencies": {
     "axios": "^0.19.2",
-    "@babel/cli": "^7.5.5",
-    "@babel/preset-react": "^7.0.0"
-  },
-  "main": "index.js",
-  "author": "alumni-labs",
-  "license": "ISC",
-  "description": "React component for submitting an email"
+    "@babel/cli": "^7.8.4",
+    "@babel/preset-react": "^7.8.3",
+    "babel-cli": "^6.26.0",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
+    "react-scripts": "3.3.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "easymailing",
-  "version": "1.0.0",
-  "description": "",
+  "version": "1.0.1",
+  "description": "Middleware for clients to send form response via email ",
   "main": "server.js",
   "dependencies": {
     "body-parser": "^1.19.0",


### PR DESCRIPTION
closes Issue #16 
Publish as npm package `easymailing` for the backend and `easymailing-client` for the frontend
To publish front-end npm package, in Terminal, navigate to front-end folder, then `npm run npm:publish` to compile with babel first, then run `npm publish`

Add basic Readme with instructions on how to use the packages